### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     name: Create Release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/omnitype/security/code-scanning/7](https://github.com/bniladridas/omnitype/security/code-scanning/7)

To fix the issue, we should add a `permissions` block to the `release` job in `.github/workflows/release.yml` (starting at line 9). The minimal required permission for creating a release is `contents: write`, as this allows the action to create and modify releases. If additional scopes are needed (for example, publishing to PRs), they should be added, but based on the shown code only `contents: write` is required. This change should be inserted directly under the job name (`name: Create Release`) and before `runs-on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
